### PR TITLE
DTO 들에 Serializable 인터페이즈 제거

### DIFF
--- a/src/main/java/com/example/springboardproject/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/example/springboardproject/dto/response/ArticleCommentResponse.java
@@ -3,7 +3,6 @@ package com.example.springboardproject.dto.response;
 import com.example.springboardproject.domain.ArticleComment;
 import com.example.springboardproject.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
@@ -15,7 +14,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+){
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);
     }

--- a/src/main/java/com/example/springboardproject/dto/response/ArticleResponse.java
+++ b/src/main/java/com/example/springboardproject/dto/response/ArticleResponse.java
@@ -3,7 +3,6 @@ package com.example.springboardproject.dto.response;
 import com.example.springboardproject.domain.Article;
 import com.example.springboardproject.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
@@ -18,7 +17,7 @@ public record ArticleResponse(
         String email,
         String nickname
 
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/com/example/springboardproject/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/example/springboardproject/dto/response/ArticleWithCommentsResponse.java
@@ -3,7 +3,6 @@ package com.example.springboardproject.dto.response;
 import com.example.springboardproject.domain.ArticleComment;
 import com.example.springboardproject.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -21,7 +20,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentsResponse) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentsResponse);


### PR DESCRIPTION
JPA Buddy를 이용해 작성한 DTO들인데, 
자동으로 `implements Serializable` 이 들어가버림
프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제