### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/example/springboardproject/domain/Article.java
+++ b/src/main/java/com/example/springboardproject/domain/Article.java
@@ -66,7 +66,7 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return id != null && id.equals(article.getId());
     }
 
     @Override

--- a/src/main/java/com/example/springboardproject/domain/ArticleComment.java
+++ b/src/main/java/com/example/springboardproject/domain/ArticleComment.java
@@ -47,7 +47,7 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/example/springboardproject/domain/UserAccount.java
+++ b/src/main/java/com/example/springboardproject/domain/UserAccount.java
@@ -44,7 +44,7 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.userId);
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override


### PR DESCRIPTION
테스트 중, 게시글 수정 시에 작성자 id와 현재 로그인 id 비교가 제대로 되지 않는 문제를 파악했다.
그래서 각 엔티티들의 `equal()` 에서 값을 제대로 비교할 수 있도록
`that.id` 가 아닌 `that.getId()` 로 수정하여
제대로 값 비교를 할 수 있도록 해주었다.