### PR TITLE
yaml 파일 오타 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,9 @@ logging:
     com.example.springboardproject: debug
     org.springframework.web.servlet: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
+spring:
+  profiles:
+    active: local
 
 ---
 
@@ -38,6 +41,9 @@ spring:
       detection-strategy: annotated
   thymeleaf3:
     decoupled-logic: true
+  config:
+    activate:
+      on-profile: local
 
 ---
 
@@ -66,6 +72,7 @@ spring:
       detection-strategy: annotated
   thymeleaf3:
     decoupled-logic: true
-  profiles:
-    active: aws
+  config:
+    activate:
+      on-profile: aws
 


### PR DESCRIPTION
`config.activate.on-profile` 과 `spring.profiles.active` 이 반대로 사용됨

이 때문에 배포 환경과 로컬 환경 모두에서 aws db를 사용하게 되는 문제가 생겨서
추가로 확인 후, 변경 해줌

This closes #58 