### PR TITLE
[리팩토링] 잘못 작성된 소스 코드 수정

### DIFF
--- a/src/main/java/com/example/springboardproject/service/ArticleService.java
+++ b/src/main/java/com/example/springboardproject/service/ArticleService.java
@@ -6,7 +6,6 @@ import com.example.springboardproject.domain.UserAccount;
 import com.example.springboardproject.domain.constant.SearchType;
 import com.example.springboardproject.dto.ArticleDto;
 import com.example.springboardproject.dto.ArticleWithCommentsDto;
-import com.example.springboardproject.dto.HashtagDto;
 import com.example.springboardproject.repository.ArticleRepository;
 import com.example.springboardproject.repository.HashtagRepository;
 import com.example.springboardproject.repository.UserAccountRepository;
@@ -77,7 +76,7 @@ public class ArticleService {
         Article article = dto.toEntity(userAccount);
         article.addHashtags(hashtags);
 
-        articleRepository.save(dto.toEntity(userAccount));
+        articleRepository.save(article);
     }
 
     public void updateArticle(Long articleId, ArticleDto dto) {


### PR DESCRIPTION
본문에서 작성된 해시태그가 페이지 내에서 표시되지 않음을 확인하고 코드 수정함

`ArticleService`에서 해시태그를 가진 게시글이 아닌 이전의 게시글이 저장됨을 확인하고 수정

This closes #115 